### PR TITLE
add libs needed for pyfesom2

### DIFF
--- a/environment-esm-vfc.yml
+++ b/environment-esm-vfc.yml
@@ -6,6 +6,8 @@ dependencies:
   - basemap
   - cartopy
   - cartopy_offlinedata
+  - cmocean
+  - cmaps
   - dask
   - dask-labextension
   - datashader
@@ -20,20 +22,25 @@ dependencies:
   - hvplot
   - intake
   - intake-xarray
+  - joblib
   - jupyter-server-proxy
   - lz4
   - matplotlib-base
   - nbgitpuller
   - netcdf4
   - nomkl
+  - numba
   - numcodecs
   - numpy
   - pandas
   - panel
   - pip
+  - pyresample
   - python-blosc
   - scipy
   - seaborn
+  - seawater
+  - shapely
   - xarray
   - xgcm
   - xhistogram


### PR DESCRIPTION
In order pyfesom2 to work, we need a bit more libraries. 