### PR TITLE
Pin python 3.7

### DIFF
--- a/environment-esm-vfc.yml
+++ b/environment-esm-vfc.yml
@@ -2,7 +2,7 @@ name: esm-vfc
 channels:
   - conda-forge
 dependencies:
-  - python=3
+  - python=3.7
   - basemap
   - cartopy
   - cartopy_offlinedata


### PR DESCRIPTION
With python 3.8, there's lots of SyntaxWarnings stemming from <https://docs.python.org/3/whatsnew/3.8.html#changes-in-python-behavior>. Let's pin 3.7 for now to avoid these and wait for the upstream packages to clean up their comparisons.